### PR TITLE
Fix Push all parquet files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ tpcds-kit/test_data/  # Ignore generated TPC-DS data
 
 # Ignore all .parquet files
 *.parquet
+venv/

--- a/tpcds-kit/parquet_transform_spark.py
+++ b/tpcds-kit/parquet_transform_spark.py
@@ -5,7 +5,6 @@ from pyspark.sql import SparkSession
 from pyspark.sql.utils import AnalysisException
 from termcolor import colored
 import sys
-from pyspark.sql.functions import monotonically_increasing_id, expr
 
 # Load schema definitions
 schema_path = os.path.join(os.path.dirname(__file__), "tpcds_schema.json")
@@ -35,6 +34,8 @@ def calculate_partitions(file_path, base_partition_size=128 * 1024 * 1024):
     :return: Number of partitions.
     """
     file_size = os.path.getsize(file_path)
+    print(f"File size: {file_size} bytes")
+    print(f"Base partition size: {base_partition_size} bytes")
     return max(1, file_size // base_partition_size)
 
 def process_file(spark, file_path):
@@ -60,20 +61,15 @@ def process_file(spark, file_path):
         # Calculate the number of partitions based on file size
         num_partitions = calculate_partitions(file_path)
 
-        # Add a partitioning column (e.g., partition_key) based on row index
-        df = df.withColumn("partition_key", expr(f"monotonically_increasing_id() % {num_partitions}"))
+        print(f"Partitioning {file_path} into {num_partitions} partitions")
 
-        # repartition
+        # Repartition to control output file count and size
+        # This creates num_partitions Spark partitions, each written as a separate parquet file
         df = df.repartition(num_partitions)
-        # also is recommended to increase the global JAVA memory heap allocation an system wide:
-        # export _JAVA_OPTIONS="-Xmx500g"
 
-        # Write DataFrame to Parquet with partitioning
-        output_folder = os.path.join(output_dir, table_name)  # Remove .parquet from folder name
-        df.write.mode("overwrite").partitionBy("partition_key").parquet(output_folder)
-
-        # Remove the partitioning column after writing
-        df = df.drop("partition_key")
+        # Write DataFrame to Parquet (without partitionBy to avoid file explosion)
+        output_folder = os.path.join(output_dir, table_name)
+        df.write.mode("overwrite").parquet(output_folder)
 
         print(f"Successfully converted {file_path} to {output_folder} with {num_partitions} partitions")
     except AnalysisException as e:

--- a/tpcds-kit/parquet_transform_spark.py
+++ b/tpcds-kit/parquet_transform_spark.py
@@ -5,6 +5,7 @@ from pyspark.sql import SparkSession
 from pyspark.sql.utils import AnalysisException
 from termcolor import colored
 import sys
+from pyspark.sql.functions import monotonically_increasing_id, expr
 
 # Load schema definitions
 schema_path = os.path.join(os.path.dirname(__file__), "tpcds_schema.json")
@@ -34,8 +35,6 @@ def calculate_partitions(file_path, base_partition_size=128 * 1024 * 1024):
     :return: Number of partitions.
     """
     file_size = os.path.getsize(file_path)
-    print(f"File size: {file_size} bytes")
-    print(f"Base partition size: {base_partition_size} bytes")
     return max(1, file_size // base_partition_size)
 
 def process_file(spark, file_path):
@@ -61,15 +60,20 @@ def process_file(spark, file_path):
         # Calculate the number of partitions based on file size
         num_partitions = calculate_partitions(file_path)
 
-        print(f"Partitioning {file_path} into {num_partitions} partitions")
+        # Add a partitioning column (e.g., partition_key) based on row index
+        df = df.withColumn("partition_key", expr(f"monotonically_increasing_id() % {num_partitions}"))
 
-        # Repartition to control output file count and size
-        # This creates num_partitions Spark partitions, each written as a separate parquet file
+        # repartition
         df = df.repartition(num_partitions)
+        # also is recommended to increase the global JAVA memory heap allocation an system wide:
+        # export _JAVA_OPTIONS="-Xmx500g"
 
-        # Write DataFrame to Parquet (without partitionBy to avoid file explosion)
-        output_folder = os.path.join(output_dir, table_name)
-        df.write.mode("overwrite").parquet(output_folder)
+        # Write DataFrame to Parquet with partitioning
+        output_folder = os.path.join(output_dir, table_name)  # Remove .parquet from folder name
+        df.write.mode("overwrite").partitionBy("partition_key").parquet(output_folder)
+
+        # Remove the partitioning column after writing
+        df = df.drop("partition_key")
 
         print(f"Successfully converted {file_path} to {output_folder} with {num_partitions} partitions")
     except AnalysisException as e:

--- a/tpcds-kit/parquet_transform_spark.py
+++ b/tpcds-kit/parquet_transform_spark.py
@@ -82,15 +82,21 @@ if __name__ == "__main__":
     parser.add_argument("--custom_dir", required=False, type=str, help="Directory for temporary files location, instead of default /tmp directory")
     args = parser.parse_args()
 
-    # Initialize Spark session
+    # Initialize Spark session with memory-safe settings
     spark = SparkSession.builder \
-        .config("spark.driver.memory", "8g") \
-        .config("spark.executor.memory", "8g") \
-        .config("spark.executor.memoryOverhead", "2g") \
+        .config("spark.driver.memory", "64g") \
+        .config("spark.executor.memory", "64g") \
+        .config("spark.executor.memoryOverhead", "8g") \
+        .config("spark.memory.fraction", "0.6") \
+        .config("spark.memory.storageFraction", "0.3") \
+        .config("spark.shuffle.spill.compress", "true") \
+        .config("spark.shuffle.compress", "true") \
+        .config("spark.default.parallelism", "64") \
+        .config("spark.sql.shuffle.partitions", "64") \
         .appName("TPC-DS Parquet Transformer") \
-        .master("local[*]")
+        .master("local[64]")
     
-    if args.custom_dir != "":
+    if args.custom_dir and args.custom_dir != "":
         spark = spark.config("spark.local.dir", args.custom_dir)
     
     spark = spark.getOrCreate()

--- a/tpcds-kit/upload_parquet.py
+++ b/tpcds-kit/upload_parquet.py
@@ -60,9 +60,6 @@ def upload_parquet_files(parquet_dir, test_mode, specific_file=None):
                 if filename.endswith(".parquet"):
                     absolute_path = os.path.join(root, filename)
                     file_path = absolute_path.replace(parquet_dir, "")
-                    print("file path:" + file_path)
-                    print("file name:" + filename)
-                    print("file root:" + root)                    
                     # Define the S3 key as "file_path", including all level folders for partitioning, ie:
                     # dbgen_version/partition_key=0/part-00000-d51598df-5887-4d3c-8145-0c9ec945fc00.c000.snappy.parquet
                     key = f"{s3_folder}{file_path}"

--- a/tpcds-kit/upload_parquet.py
+++ b/tpcds-kit/upload_parquet.py
@@ -57,13 +57,13 @@ def upload_parquet_files(parquet_dir, test_mode, specific_file=None):
                 if filename.endswith(".parquet"):
                     absolute_path = os.path.join(root, filename)
                     file_path = absolute_path.replace(parquet_dir, "")
-                    # print("file path:" + file_path)
-                    # print("file name:" + filename)
-                    # print("file root:" + root)
-                    # print("table name:" + file_path.split(os.sep)[0])
+                    print("file path:" + file_path)
+                    print("file name:" + filename)
+                    print("file root:" + root)                    
                     # Define the S3 key as "file_path", including all level folders for partitioning, ie:
                     # dbgen_version/partition_key=0/part-00000-d51598df-5887-4d3c-8145-0c9ec945fc00.c000.snappy.parquet
-                    key = f"{s3_folder}/{file_path}"
+                    key = f"{s3_folder}{file_path}"
+                    print("s3 key:" + key)
                     if test_mode:
                         print(f"TEST MODE: Source: {absolute_path}, Target: s3://{s3_bucket}/{key}")
                     else:

--- a/tpcds-kit/upload_parquet.py
+++ b/tpcds-kit/upload_parquet.py
@@ -1,6 +1,7 @@
 import os
 import argparse
 import boto3
+import urllib3
 from botocore.exceptions import NoCredentialsError
 from dotenv import load_dotenv
 
@@ -19,6 +20,8 @@ def upload_parquet_files(parquet_dir, test_mode, specific_file=None):
         print("\033[91mEnvironment variables S3_BUCKET_NAME, S3_ENDPOINT_URL, S3_ACCESS_KEY, and S3_SECRET_KEY must be set.\033[0m")
         print("\033[91mHint: Try running 'tpcds.py cleanup' before attempting again.\033[0m")
         return
+    # Disable TLS warnings from urllib3
+    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
     # Create an S3 client using environment variables
     s3 = boto3.client(

--- a/tpcds-kit/upload_parquet.py
+++ b/tpcds-kit/upload_parquet.py
@@ -25,7 +25,8 @@ def upload_parquet_files(parquet_dir, test_mode, specific_file=None):
         's3',
         endpoint_url=s3_endpoint,
         aws_access_key_id=s3_access_key,
-        aws_secret_access_key=s3_secret_key
+        aws_secret_access_key=s3_secret_key,
+        verify=False
     )
 
     if specific_file:
@@ -51,25 +52,29 @@ def upload_parquet_files(parquet_dir, test_mode, specific_file=None):
                 return
     else:
         # Iterate through each file in the parquet directory
-        for filename in os.listdir(parquet_dir):
-            if filename.endswith(".parquet"):
-                file_path = os.path.join(parquet_dir, filename)
-                # Use the base name (without extension) as the table name
-                table_name = os.path.splitext(filename)[0]
-                # Define the S3 key as "table_name/filename.parquet"
-                key = f"{s3_folder}/{table_name}/{filename}"
-
-                if test_mode:
-                    print(f"TEST MODE: Source: {file_path}, Target: s3://{s3_bucket}/{key}")
-                else:
-                    print(f"Uploading {file_path} to s3://{s3_bucket}/{key}")
-                    try:
-                        s3.upload_file(file_path, s3_bucket, key)
-                        print("Upload successful")
-                    except NoCredentialsError:
-                        print("\033[91mCredentials not available. Please ensure S3_ACCESS_KEY and S3_SECRET_KEY are set.\033[0m")
-                        print("\033[91mHint: Try running 'tpcds.py cleanup' before attempting again.\033[0m")
-                        return
+        for root, dirs, files in os.walk(parquet_dir):
+            for filename in files:
+                if filename.endswith(".parquet"):
+                    absolute_path = os.path.join(root, filename)
+                    file_path = absolute_path.replace(parquet_dir, "")
+                    # print("file path:" + file_path)
+                    # print("file name:" + filename)
+                    # print("file root:" + root)
+                    # print("table name:" + file_path.split(os.sep)[0])
+                    # Define the S3 key as "file_path", including all level folders for partitioning, ie:
+                    # dbgen_version/partition_key=0/part-00000-d51598df-5887-4d3c-8145-0c9ec945fc00.c000.snappy.parquet
+                    key = f"{s3_folder}/{file_path}"
+                    if test_mode:
+                        print(f"TEST MODE: Source: {absolute_path}, Target: s3://{s3_bucket}/{key}")
+                    else:
+                        print(f"Uploading {absolute_path} to s3://{s3_bucket}/{key}")
+                        try:
+                            s3.upload_file(absolute_path, s3_bucket, key)
+                            print("Upload successful")
+                        except NoCredentialsError:
+                            print("\033[91mCredentials not available. Please ensure S3_ACCESS_KEY and S3_SECRET_KEY are set.\033[0m")
+                            print("\033[91mHint: Try running 'tpcds.py cleanup' before attempting again.\033[0m")
+                            return
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Upload Parquet files to S3-compatible storage")

--- a/tpcds.py
+++ b/tpcds.py
@@ -5,6 +5,7 @@ import argparse
 import os
 import subprocess
 import shutil
+import glob
 from dotenv import load_dotenv
 
 # Adjust paths to work from the root directory
@@ -15,13 +16,13 @@ PARQUET_DIR = os.path.join(TPCDS_KIT_DIR, "test_data/parquet")
 # Load environment variables
 load_dotenv()
 
-def generate_data(scale_factor):
+def generate_data(scale_factor, non_interactive=False):
     print(f"You are about to generate approximately {scale_factor}GB of data.")
-    confirmation = input("Do you want to proceed? (y/n): ").strip().lower()
-    if confirmation != "y":
-        print("Operation cancelled.")
-        return
-
+    if not non_interactive:
+        confirmation = input("Do you want to proceed? (y/n): ").strip().lower()
+        if confirmation != "y":
+            print("Operation cancelled.")
+            return
     subprocess.run(["python", os.path.join(TPCDS_KIT_DIR, "data_generator.py"), "--scale-factor", str(scale_factor)])
 
 def upload_data(test_mode, use_spark, custom_tmp_dir=""):
@@ -58,7 +59,7 @@ def upload_data(test_mode, use_spark, custom_tmp_dir=""):
         subprocess.run(["python", os.path.join(TPCDS_KIT_DIR, "data_to_parquet.py")])
 
     # Check if parquet files exist
-    if not os.path.exists(PARQUET_DIR) or not any(f.endswith(".parquet") for f in os.listdir(PARQUET_DIR)):
+    if not os.path.exists(PARQUET_DIR) or not glob.glob(f'{PARQUET_DIR}/**/*.parquet', recursive=True):
         print("No .parquet files found in 'test_data/parquet'. Nothing to upload.")
         return
 
@@ -66,12 +67,13 @@ def upload_data(test_mode, use_spark, custom_tmp_dir=""):
     command = ["python", os.path.join(TPCDS_KIT_DIR, "upload_parquet.py"), "--directory", PARQUET_DIR]
     subprocess.run(command)
 
-def cleanup():
-    print("WARNING: This will delete all .dat files in 'test_data/raw_files' and all .parquet files in 'test_data/parquet'.")
-    confirmation = input("Do you want to proceed? (y/n): ").strip().lower()
-    if confirmation != "y":
-        print("Operation cancelled.")
-        return
+def cleanup(non_interactive=False):
+    if not non_interactive:
+        print("WARNING: This will delete all .dat files in 'test_data/raw_files' and all .parquet files in 'test_data/parquet'.")
+        confirmation = input("Do you want to proceed? (y/n): ").strip().lower()
+        if confirmation != "y":
+            print("Operation cancelled.")
+            return
 
     # Delete .dat files
     if os.path.exists(RAW_FILES_DIR):
@@ -89,6 +91,7 @@ def cleanup():
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="TPC-DS Test Kit: Manage data generation, conversion, upload, and cleanup.")
+    parser.add_argument("--yes", action="store_true", help="Non-interactive mode, assume yes to prompts")
     subparsers = parser.add_subparsers(dest="command", required=True)
 
     # Subparser for data generation
@@ -107,8 +110,8 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     if args.command == "generate":
-        generate_data(args.scale)
+        generate_data(args.scale, args.yes)
     elif args.command == "upload":
         upload_data(args.test, args.spark, args.custom_dir)
     elif args.command == "cleanup":
-        cleanup()
+        cleanup(args.yes)


### PR DESCRIPTION
## Fix upload parquet files

Originally the upload_parquet.py looks for the .parquet files in the top directory of `perf_testing/tpcds-kit/test_data/parquet` and uploads all files to a top directory called "table", this works well when there is not partitioning and all parquet files are in root directory, which is not desired in bigger data sets, is prefferable to partiton and upload smaller files instead of a huge single parquet file.

This change walks the top directory `perf_testing/tpcds-kit/test_data/parquet` and upload all files under it where a .parquet file exists, including the in-middle directory partition name, ie: `dbgen_version/partition_key=0/part-00000-d51598df-5887-4d3c-8145-0c9ec945fc00.c000.snappy.parquet`

## Fix TLS verification

If a the target S3 is using a elf-signet TLS certificate or not trusted the upload will fail, this change disables TLS certificate validation.

## Feature, non-interactive call

If you call the comand wiwth `python tpcds.py generate` or `python tpcds cleanup` it allways promts and expects a "yes" in the stdin input, making it harder to script, this feature adds the non-interactive argument `--yes` at top level.

```sh
python tpcds.py --yes cleanup

python tpcds.py --yes generate  --scale=1 
```


## Fix: overpartitioning

Remove partition key to prevent permitation resulting in thousands of 64Kb files instead of chunks of 128Mb (source file chunk).

128MB raw data partitions resulting in ~43-53MB compressed output files